### PR TITLE
Fix inexecutable code snippet on Conditional Expression

### DIFF
--- a/examples/02_control_flow/05_Conditional expression.md
+++ b/examples/02_control_flow/05_Conditional expression.md
@@ -2,7 +2,7 @@
 
 There is no ternary operator `condition ? then : else` in Kotlin. Instead, `if` may be used as an expression:
 
-```kotlin
+```run-kotlin
 fun main() {
 //sampleStart
     fun max(a: Int, b: Int) = if (a > b) a else b         // 1


### PR DESCRIPTION
The example on [Conditional Expression](https://play.kotlinlang.org/byExample/02_control_flow/05_Conditional%20expression) isn't executable on web browser owing to wrong syntax highlighting. 

Replace `kotlin` with `run-kotlin` to fix the issue