### PR TITLE
Clean up partition explanation

### DIFF
--- a/examples/05_Collections/11_partition.md
+++ b/examples/05_Collections/11_partition.md
@@ -1,8 +1,9 @@
 # partition
 
-`partition` function splits the original collection into pair of lists using a given predicate:
- * Elements for which the predicate is `true`.
- * Elements for which the predicate is `false`.
+The `partition` function splits the original collection into a pair of lists using a given predicate:
+
+ 1. Elements for which the predicate is `true`.
+ 1. Elements for which the predicate is `false`.
 
 ```run-kotlin
 fun main() {


### PR DESCRIPTION
## Problem

The explanation of the `partition` function is rendering incorrectly on the published web site, translating what should be a bulleted list into an emphasis (`em`) tag around one of the points.

<img width="1027" alt="Screen Shot 2020-08-10 at 8 40 45 PM" src="https://user-images.githubusercontent.com/36460/89844625-2a2ee280-db4a-11ea-95d5-c5d580124709.png">

## Solution

* add a blank line before the list
* use a numbered list instead of bullets, to more clearly indicate that there are two lists returned
* minor grammar fixes

I don't know if this will actually fix the rendering, but I assume it will be significantly different :)