### PR TITLE
Delegate properties adjustment

### DIFF
--- a/examples/05_Collections/13_max.md
+++ b/examples/05_Collections/13_max.md
@@ -9,8 +9,8 @@ fun main() {
     val numbers = listOf(1, 2, 3)
     val empty = emptyList<Int>()
 
-    println("Numbers: $numbers, min = ${numbers.min()} max = ${numbers.max()}") // 1
-    println("Empty: $empty, min = ${empty.min()}, max = ${empty.max()}")        // 2
+    println("Numbers: $numbers, min = ${numbers.minOrNull()} max = ${numbers.maxOrNull()}") // 1
+    println("Empty: $empty, min = ${empty.minOrNull()}, max = ${empty.maxOrNull()}")        // 2
 //sampleEnd
 }
 ```

--- a/examples/05_Collections/13_max.md
+++ b/examples/05_Collections/13_max.md
@@ -1,6 +1,6 @@
-# min, max
+# minOrNull, maxOrNull
 
-`min` and `max` functions return the smallest and the largest element of a collection. If the collection is empty, they return `null`.
+`minOrNull` and `maxOrNull` functions return the smallest and the largest element of a collection. If the collection is empty, they return `null`.
 
 ```run-kotlin
 fun main() {

--- a/examples/05_Collections/14_sorted.md
+++ b/examples/05_Collections/14_sorted.md
@@ -10,8 +10,6 @@ import kotlin.math.abs
 fun main() {
 
 //sampleStart
-    import java.lang.Math.abs
-
     val shuffled = listOf(5, 4, 2, 1, 3, -10)                   // 1
     val natural = shuffled.sorted()                             // 2
     val inverted = shuffled.sortedBy { -it }                    // 3

--- a/examples/05_Collections/14_sorted.md
+++ b/examples/05_Collections/14_sorted.md
@@ -10,6 +10,8 @@ import kotlin.math.abs
 fun main() {
 
 //sampleStart
+    import java.lang.Math.abs
+
     val shuffled = listOf(5, 4, 2, 1, 3, -10)                   // 1
     val natural = shuffled.sorted()                             // 2
     val inverted = shuffled.sortedBy { -it }                    // 3

--- a/examples/07_Delegation/02_DelegatedProperties.md
+++ b/examples/07_Delegation/02_DelegatedProperties.md
@@ -6,12 +6,6 @@ The delegate object in this case should have the method `getValue`. For mutable 
 ```run-kotlin
 import kotlin.reflect.KProperty
 
-class Example {
-    var p: String by Delegate()                                               // 1
-
-    override fun toString() = "Example Class"
-}
-
 class Delegate() {
     operator fun getValue(thisRef: Any?, prop: KProperty<*>): String {        // 2     
         return "$thisRef, thank you for delegating '${prop.name}' to me!"
@@ -20,6 +14,12 @@ class Delegate() {
     operator fun setValue(thisRef: Any?, prop: KProperty<*>, value: String) { // 2
         println("$value has been assigned to ${prop.name} in $thisRef")
     }
+}
+
+class Example {
+    var p: String by Delegate()                                               // 1
+
+    override fun toString() = "Example Class"
 }
 
 fun main() {


### PR DESCRIPTION
While working through the Delegate Properties example I noticed that the `Delegate` class in the example is referenced  before its declaration, so this PR moves the declaration up so it's available when it's referenced in the `Example` class. 

There's also another commit in here from a PR I made two days ago that was already merged so I'm not sure why it's showing here. If there's something I need to do to fix it please let me know. 

Thanks!