### PR TITLE
Adjusting class definition order in Delegated Properties example

### DIFF
--- a/examples/07_Delegation/02_DelegatedProperties.md
+++ b/examples/07_Delegation/02_DelegatedProperties.md
@@ -6,12 +6,6 @@ The delegate object in this case should have the method `getValue`. For mutable 
 ```run-kotlin
 import kotlin.reflect.KProperty
 
-class Example {
-    var p: String by Delegate()                                               // 1
-
-    override fun toString() = "Example Class"
-}
-
 class Delegate() {
     operator fun getValue(thisRef: Any?, prop: KProperty<*>): String {        // 2     
         return "$thisRef, thank you for delegating '${prop.name}' to me!"
@@ -20,6 +14,12 @@ class Delegate() {
     operator fun setValue(thisRef: Any?, prop: KProperty<*>, value: String) { // 2
         println("$value has been assigned to ${prop.name} in $thisRef")
     }
+}
+
+class Example {
+    var p: String by Delegate()                                               // 1
+
+    override fun toString() = "Example Class"
 }
 
 fun main() {


### PR DESCRIPTION
As I was working through the Delegated Properties example I noticed that the `Delegate` class is referenced in the `Example` class before the former class is defined, so it pops up an error in intellij

![Screen Shot 2020-12-18 at 11 40 28 AM](https://user-images.githubusercontent.com/2437424/102644157-f4b48a00-4125-11eb-916a-4093254fccae.png)

This PR moves the class definition for `Delegate` up so it's ready for its use in `Example`.