### PR TITLE
Resolve a deprecation warning

### DIFF
--- a/examples/04_functional/03_extensionFunctions.md
+++ b/examples/04_functional/03_extensionFunctions.md
@@ -3,23 +3,23 @@
 Kotlin lets you add new members to any class with the [extensions](https://kotlinlang.org/docs/reference/extensions.html) mechanism. Namely, there are two types of extensions: extension functions and extension properties. They look a lot like normal functions and properties but with one important difference: you need to specify the type that you extend.
 
 ```run-kotlin
-data class Item(val name: String, val price: Float)                                   // 1  
+data class Item(val name: String, val price: Float)                                         // 1  
 
 data class Order(val items: Collection<Item>)  
 
-fun Order.maxPricedItemValue(): Float = this.items.maxBy { it.price }?.price ?: 0F    // 2  
-fun Order.maxPricedItemName() = this.items.maxBy { it.price }?.name ?: "NO_PRODUCTS"
+fun Order.maxPricedItemValue(): Float = this.items.maxByOrNull { it.price }?.price ?: 0F    // 2  
+fun Order.maxPricedItemName() = this.items.maxByOrNull { it.price }?.name ?: "NO_PRODUCTS"
 
-val Order.commaDelimitedItemNames: String                                             // 3
+val Order.commaDelimitedItemNames: String                                                   // 3
     get() = items.map { it.name }.joinToString()
 
 fun main() {
 
     val order = Order(listOf(Item("Bread", 25.0F), Item("Wine", 29.0F), Item("Water", 12.0F)))
     
-    println("Max priced item name: ${order.maxPricedItemName()}")                     // 4
+    println("Max priced item name: ${order.maxPricedItemName()}")                           // 4
     println("Max priced item value: ${order.maxPricedItemValue()}")
-    println("Items: ${order.commaDelimitedItemNames}")                                // 5
+    println("Items: ${order.commaDelimitedItemNames}")                                      // 5
 
 }
 ```


### PR DESCRIPTION
The compiler complained that 'maxBy((T) -> R): T?' is deprecated and
should be replaced with maxByOrNull.