### PR TITLE
Rename addSudoer() to addSystemUser()

### DIFF
--- a/examples/05_Collections/01_List.md
+++ b/examples/05_Collections/01_List.md
@@ -6,7 +6,7 @@ A [list](https://kotlinlang.org/docs/reference/collections.html) is an ordered c
 val systemUsers: MutableList<Int> = mutableListOf(1, 2, 3)        // 1
 val sudoers: List<Int> = systemUsers                              // 2
 
-fun addSudoer(newUser: Int) {                                     // 3
+fun addSystemUser(newUser: Int) {                                 // 3
     systemUsers.add(newUser)                      
 }
 
@@ -15,7 +15,7 @@ fun getSysSudoers(): List<Int> {                                  // 4
 }
 
 fun main() {
-    addSudoer(4)                                                  // 5 
+    addSystemUser(4)                                              // 5 
     println("Tot sudoers: ${getSysSudoers().size}")               // 6
     getSysSudoers().forEach {                                     // 7
         i -> println("Some useful info on user $i")


### PR DESCRIPTION
addSudoer() actually adds newUser to systemUsers, not sudoers.  
So it looks better renaming addSudoer() to addSystemUser().