### PR TITLE
toUpperCase() is deprecated

### DIFF
--- a/examples/04_functional/02_Lambdas.md
+++ b/examples/04_functional/02_Lambdas.md
@@ -8,17 +8,17 @@ fun main() {
     // All examples create a function object that performs upper-casing.
     // So it's a function from String to String
 
-    val upperCase1: (String) -> String = { str: String -> str.toUpperCase() } // 1
+    val upperCase1: (String) -> String = { str: String -> str.uppercase() } // 1
 
-    val upperCase2: (String) -> String = { str -> str.toUpperCase() }         // 2
+    val upperCase2: (String) -> String = { str -> str.uppercase() }         // 2
 
-    val upperCase3 = { str: String -> str.toUpperCase() }                     // 3
+    val upperCase3 = { str: String -> str.uppercase() }                     // 3
 
-    // val upperCase4 = { str -> str.toUpperCase() }                          // 4
+    // val upperCase4 = { str -> str.uppercase() }                          // 4
 
-    val upperCase5: (String) -> String = { it.toUpperCase() }                 // 5
+    val upperCase5: (String) -> String = { it.uppercase() }                 // 5
 
-    val upperCase6: (String) -> String = String::toUpperCase                  // 6
+    val upperCase6: (String) -> String = String::uppercase                  // 6
 
     println(upperCase1("hello"))
     println(upperCase2("hello"))


### PR DESCRIPTION
In last versions of Kotlin method 'toUpperCase()' is deprecated, but you can use 'uppercase()' method