### PR TITLE
fix: replace comma by semicolon

### DIFF
--- a/examples/03_special_classes/02_Enum.md
+++ b/examples/03_special_classes/02_Enum.md
@@ -48,7 +48,7 @@ fun main() {
 
 1. Defines an enum class with a property and a method.
 2. Each instance must pass an argument for the constructor parameter.
-3. Enum class members are separated from the instance definitions by a semicolon.
+3. Enum class members are separated from the instance definitions by a comma.
 4. The default `toString` returns the name of the instance, here `"RED"`.
 5. Calls a method on an enum instance.
 6. Calls a method via enum class name.


### PR DESCRIPTION
Enum class members are separated from the instance definitions by a semicolon.

semicolon should be replaced by comma.