### PR TITLE
fix: typo in Kotlin JS Canvas example

### DIFF
--- a/examples/09_Kotlin_JS/05_Canvas.md
+++ b/examples/09_Kotlin_JS/05_Canvas.md
@@ -20,9 +20,9 @@ fun getImage(path: String): HTMLImageElement {
     return image
 }
 
-val canvas = initalizeCanvas()
+val canvas = initializeCanvas()
 
-fun initalizeCanvas(): HTMLCanvasElement {
+fun initializeCanvas(): HTMLCanvasElement {
     val canvas = document.createElement("canvas") as HTMLCanvasElement
     val context = canvas.getContext("2d") as CanvasRenderingContext2D
     context.canvas.width  = window.innerWidth.toInt()


### PR DESCRIPTION
found a small typo when I played around with the JS canvas example.